### PR TITLE
Modify recoverFeatureFromMapLandmarks

### DIFF
--- a/cpp/include/isaeslam/slamCore.h
+++ b/cpp/include/isaeslam/slamCore.h
@@ -181,12 +181,11 @@ class SLAMCore {
     /*!
      * @brief Performs landmark resurection
      *
-     * @param localmap Local maps that contains the landmark to project
-     * @param f Frame on which the landmarks are resurected
+     * @param sensor Sensor on which the landmarks are resurected
      *
      * @return The number of resurected landmarks
      */
-    uint recoverFeatureFromMapLandmarks(std::shared_ptr<isae::AMap> localmap, std::shared_ptr<Frame> &f);
+    uint recoverFeatureFromMapLandmarks(std::shared_ptr<ImageSensor> &sensor);
 
     /*!
      * @brief Determines if the frame in argument is a KF

--- a/cpp/src/slamBiMono.cpp
+++ b/cpp/src/slamBiMono.cpp
@@ -173,9 +173,8 @@ bool SLAMBiMono::frontEndStep() {
 
         // Recover Map Landmark
         isae::timer::tic();
-        _map_mutex.lock();
-        uint resu = recoverFeatureFromMapLandmarks(_local_map, _frame);
-        _map_mutex.unlock();
+        uint resu = recoverFeatureFromMapLandmarks(_frame->getSensors().at(0));
+        
         _avg_lmk_resur_t = (_avg_lmk_resur_t * (_nkeyframes - 1) + isae::timer::silentToc()) / _nkeyframes;
         _avg_resur_lmk   = (_avg_lmk_resur_t * (_nkeyframes - 1) + resu) / _nkeyframes;
 

--- a/cpp/src/slamBiMonoVIO.cpp
+++ b/cpp/src/slamBiMonoVIO.cpp
@@ -262,7 +262,7 @@ bool SLAMBiMonoVIO::step_init() {
 
         // Recover Map Landmark
         isae::timer::tic();
-        uint resu = recoverFeatureFromMapLandmarks(_local_map, _frame);
+        uint resu = recoverFeatureFromMapLandmarks(_frame->getSensors().at(0));
 
         _avg_lmk_resur_t = (_avg_lmk_resur_t * (_nkeyframes - 1) + isae::timer::silentToc()) / _nkeyframes;
         _avg_resur_lmk   = (_avg_lmk_resur_t * (_nkeyframes - 1) + resu) / _nkeyframes;
@@ -469,9 +469,7 @@ bool SLAMBiMonoVIO::frontEndStep() {
 
         // Recover Map Landmark
         isae::timer::tic();
-        _map_mutex.lock();
-        uint resu = recoverFeatureFromMapLandmarks(_local_map, _frame);
-        _map_mutex.unlock();
+        uint resu = recoverFeatureFromMapLandmarks(_frame->getSensors().at(0));
 
         float recover_dt = isae::timer::silentToc();
         _avg_lmk_resur_t = (_avg_lmk_resur_t * (_nkeyframes - 1) + recover_dt) / _nkeyframes;

--- a/cpp/src/slamCore.cpp
+++ b/cpp/src/slamCore.cpp
@@ -227,13 +227,15 @@ typed_vec_match SLAMCore::epipolarFiltering(std::shared_ptr<ImageSensor> &cam0,
     return valid_matches;
 }
 
-uint SLAMCore::recoverFeatureFromMapLandmarks(std::shared_ptr<isae::AMap> localmap, std::shared_ptr<Frame> &f) {
+uint SLAMCore::recoverFeatureFromMapLandmarks(std::shared_ptr<ImageSensor> &sensor) {
     uint nb_resurected = 0;
 
+    _map_mutex.lock();
     for (auto typed_ldmk : localmap->getLandmarks()) {
         nb_resurected += _slam_param->getFeatureMatchers()[typed_ldmk.first].feature_matcher->ldmk_match(
-            f->getSensors().at(0), typed_ldmk.second, 5, 5);
+            sensor, typed_ldmk.second, 5, 5);
     }
+    _map_mutex.unlock();
 
     return nb_resurected;
 }

--- a/cpp/src/slamMono.cpp
+++ b/cpp/src/slamMono.cpp
@@ -235,9 +235,7 @@ bool SLAMMono::frontEndStep() {
 
         // Recover Map Landmark
         isae::timer::tic();
-        _map_mutex.lock();
-        uint resu = recoverFeatureFromMapLandmarks(_local_map, _frame);
-        _map_mutex.unlock();
+        uint resu = recoverFeatureFromMapLandmarks(_frame->getSensors().at(0));
 
         _avg_lmk_resur_t = (_avg_lmk_resur_t * (_nkeyframes - 1) + isae::timer::silentToc()) / _nkeyframes;
         _avg_resur_lmk   = (_avg_lmk_resur_t * (_nkeyframes - 1) + resu) / _nkeyframes;

--- a/cpp/src/slamMonoVIO.cpp
+++ b/cpp/src/slamMonoVIO.cpp
@@ -366,7 +366,7 @@ bool SLAMMonoVIO::step_init() {
 
         // Recover Map Landmark
         isae::timer::tic();
-        uint resu = recoverFeatureFromMapLandmarks(_local_map, _frame);
+        uint resu = recoverFeatureFromMapLandmarks(_frame->getSensors().at(0));
 
         _avg_lmk_resur_t = (_avg_lmk_resur_t * (_nkeyframes - 1) + isae::timer::silentToc()) / _nkeyframes;
         _avg_resur_lmk   = (_avg_lmk_resur_t * (_nkeyframes - 1) + resu) / _nkeyframes;
@@ -555,9 +555,7 @@ bool SLAMMonoVIO::frontEndStep() {
 
         // Recover Map Landmark
         isae::timer::tic();
-        _map_mutex.lock();
-        uint resu = recoverFeatureFromMapLandmarks(_local_map, _frame);
-        _map_mutex.unlock();
+        uint resu = recoverFeatureFromMapLandmarks(_frame->getSensors().at(0));
 
         _avg_lmk_resur_t = (_avg_lmk_resur_t * (_nkeyframes - 1) + isae::timer::silentToc()) / _nkeyframes;
         _avg_resur_lmk   = (_avg_lmk_resur_t * (_nkeyframes - 1) + resu) / _nkeyframes;

--- a/cpp/src/slamNonOverlappingFov.cpp
+++ b/cpp/src/slamNonOverlappingFov.cpp
@@ -290,9 +290,7 @@ bool SLAMNonOverlappingFov::frontEndStep() {
 
         // Recover Map Landmark
         isae::timer::tic();
-        _map_mutex.lock();
-        uint resu = recoverFeatureFromMapLandmarks(_local_map, _frame);
-        _map_mutex.unlock();
+        uint resu = recoverFeatureFromMapLandmarks(_frame->getSensors().at(0));
 
         _avg_lmk_resur_t = (_avg_lmk_resur_t * (_nkeyframes - 1) + isae::timer::silentToc()) / _nkeyframes;
         _avg_resur_lmk   = (_avg_lmk_resur_t * (_nkeyframes - 1) + resu) / _nkeyframes;


### PR DESCRIPTION
now: gets ImageSensor instead of map (class attribute) and frame.
map mutex lock and unlock inside of method.
Modify Slam*.cpp codes accordingly and brief.

Advice : add recoverFeatureFromMapLandmarks call for the other camera of non-overlapping SLAM 